### PR TITLE
replace buffertools with buffer-equal

### DIFF
--- a/lib/Packet.js
+++ b/lib/Packet.js
@@ -1,4 +1,4 @@
-var buffertools = require('buffertools');
+var bufferEqual = require('buffer-equal');
 
 /**
  * Represents a packet.
@@ -114,6 +114,6 @@ Packet.prototype.equals = function (packet) {
     this.getIsFinish() === packet.getIsFinish() &&
     this.getIsReset() === packet.getIsReset() &&
     this.getSequenceNumber() === packet.getSequenceNumber() &&
-    buffertools.compare(this.getPayload(), packet.getPayload()) === 0
+    bufferEqual(this.getPayload(), packet.getPayload())
   )
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sinon": "^1.9.1"
   },
   "dependencies": {
-    "buffertools": "^2.1.2"
+    "buffer-equal": "0.0.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
node-rudp only uses the buffer comparison method, so this is a smaller dep. Also buffertools is not browserifiable.