### PR TITLE
Buffer.isBuffer instead of instanceof

### DIFF
--- a/lib/Packet.js
+++ b/lib/Packet.js
@@ -8,7 +8,7 @@ var bufferEqual = require('./bufferEqual');
  */
 module.exports = Packet;
 function Packet(sequenceNumber, payload, synchronize, reset) {
-  if (sequenceNumber instanceof Buffer) {
+  if (Buffer.isBuffer(sequenceNumber)) {
     var segment = sequenceNumber;
 
     var offset = 0;


### PR DESCRIPTION
for compatibility with non-nodejs environments (where Buffer is typically Uint8Array augmented with Buffer methods) https://nodejs.org/api/buffer.html#buffer_class_method_buffer_isbuffer_obj